### PR TITLE
Added check for  components because this returns a valid date in iOS 7

### DIFF
--- a/ISO8601/NSDate+ISO8601.m
+++ b/ISO8601/NSDate+ISO8601.m
@@ -20,7 +20,8 @@
 
 + (NSDate *)dateWithISO8601String:(NSString *)string timeZone:(inout NSTimeZone *__autoreleasing *)timeZone usingCalendar:(NSCalendar *)calendar {
 	NSDateComponents *components = [ISO8601Serialization dateComponentsForString:string];
-	
+    if (components == nil) return nil;
+
 	if (!calendar) {
 		calendar = [NSCalendar currentCalendar];
 	}

--- a/Tests/DateTests.swift
+++ b/Tests/DateTests.swift
@@ -19,6 +19,10 @@ class DateTests: XCTestCase {
 		XCTAssertEqual(NSDate(ISO8601String: "2014-07-30T15:35:23-07:00", timeZone: &timeZone, usingCalendar: nil), NSDate(timeIntervalSince1970: 1406759723))
 		XCTAssertEqual(timeZone!.secondsFromGMT, -7 * 3600)
 	}
+
+    func testFailingReading() {
+        XCTAssertNil(NSDate(ISO8601String: "WRONG DATA"))
+    }
 	
 	func testWriting() {
 		XCTAssertEqual(NSDate(timeIntervalSince1970: 1406759723).ISO8601String()!, "2014-07-30T15:35:23-07:00")


### PR DESCRIPTION
Hey.

We've got a bug where invalid data (i.e. `@"WRONG DATA"`) will return a valid (but stupid) `NSDate` only in iOS 7. We tracked this down to `NSCalendar` returning a real date if you pass in `nil` as your components. Sigh.