### PR TITLE
Use explicit scheme names

### DIFF
--- a/ISO8601.xcodeproj/xcshareddata/xcschemes/ISO8601-OSX.xcscheme
+++ b/ISO8601.xcodeproj/xcshareddata/xcschemes/ISO8601-OSX.xcscheme
@@ -14,9 +14,9 @@
             buildForAnalyzing = "YES">
             <BuildableReference
                BuildableIdentifier = "primary"
-               BlueprintIdentifier = "21B3A3D619894F4600322041"
+               BlueprintIdentifier = "212539B51B1595FD00F29EF3"
                BuildableName = "ISO8601.framework"
-               BlueprintName = "iOS"
+               BlueprintName = "OSX"
                ReferencedContainer = "container:ISO8601.xcodeproj">
             </BuildableReference>
          </BuildActionEntry>
@@ -28,27 +28,27 @@
             buildForAnalyzing = "YES">
             <BuildableReference
                BuildableIdentifier = "primary"
-               BlueprintIdentifier = "21B3A3E119894F4600322041"
-               BuildableName = "ISO8601Tests-iOS.xctest"
-               BlueprintName = "iOSTests"
+               BlueprintIdentifier = "212539BF1B1595FD00F29EF3"
+               BuildableName = "ISO8601Tests-OSX.xctest"
+               BlueprintName = "OSXTests"
                ReferencedContainer = "container:ISO8601.xcodeproj">
             </BuildableReference>
          </BuildActionEntry>
       </BuildActionEntries>
    </BuildAction>
    <TestAction
+      buildConfiguration = "Debug"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
-      shouldUseLaunchSchemeArgsEnv = "YES"
-      buildConfiguration = "Debug">
+      shouldUseLaunchSchemeArgsEnv = "YES">
       <Testables>
          <TestableReference
             skipped = "NO">
             <BuildableReference
                BuildableIdentifier = "primary"
-               BlueprintIdentifier = "21B3A3E119894F4600322041"
-               BuildableName = "ISO8601Tests-iOS.xctest"
-               BlueprintName = "iOSTests"
+               BlueprintIdentifier = "212539BF1B1595FD00F29EF3"
+               BuildableName = "ISO8601Tests-OSX.xctest"
+               BlueprintName = "OSXTests"
                ReferencedContainer = "container:ISO8601.xcodeproj">
             </BuildableReference>
          </TestableReference>
@@ -56,9 +56,9 @@
       <MacroExpansion>
          <BuildableReference
             BuildableIdentifier = "primary"
-            BlueprintIdentifier = "21B3A3D619894F4600322041"
+            BlueprintIdentifier = "212539B51B1595FD00F29EF3"
             BuildableName = "ISO8601.framework"
-            BlueprintName = "iOS"
+            BlueprintName = "OSX"
             ReferencedContainer = "container:ISO8601.xcodeproj">
          </BuildableReference>
       </MacroExpansion>
@@ -66,11 +66,11 @@
       </AdditionalOptions>
    </TestAction>
    <LaunchAction
+      buildConfiguration = "Debug"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
       launchStyle = "0"
       useCustomWorkingDirectory = "NO"
-      buildConfiguration = "Debug"
       ignoresPersistentStateOnLaunch = "NO"
       debugDocumentVersioning = "YES"
       debugServiceExtension = "internal"
@@ -78,9 +78,9 @@
       <MacroExpansion>
          <BuildableReference
             BuildableIdentifier = "primary"
-            BlueprintIdentifier = "21B3A3D619894F4600322041"
+            BlueprintIdentifier = "212539B51B1595FD00F29EF3"
             BuildableName = "ISO8601.framework"
-            BlueprintName = "iOS"
+            BlueprintName = "OSX"
             ReferencedContainer = "container:ISO8601.xcodeproj">
          </BuildableReference>
       </MacroExpansion>
@@ -88,17 +88,17 @@
       </AdditionalOptions>
    </LaunchAction>
    <ProfileAction
+      buildConfiguration = "Release"
       shouldUseLaunchSchemeArgsEnv = "YES"
       savedToolIdentifier = ""
       useCustomWorkingDirectory = "NO"
-      buildConfiguration = "Release"
       debugDocumentVersioning = "YES">
       <MacroExpansion>
          <BuildableReference
             BuildableIdentifier = "primary"
-            BlueprintIdentifier = "21B3A3D619894F4600322041"
+            BlueprintIdentifier = "212539B51B1595FD00F29EF3"
             BuildableName = "ISO8601.framework"
-            BlueprintName = "iOS"
+            BlueprintName = "OSX"
             ReferencedContainer = "container:ISO8601.xcodeproj">
          </BuildableReference>
       </MacroExpansion>

--- a/ISO8601.xcodeproj/xcshareddata/xcschemes/ISO8601-iOS.xcscheme
+++ b/ISO8601.xcodeproj/xcshareddata/xcschemes/ISO8601-iOS.xcscheme
@@ -14,9 +14,9 @@
             buildForAnalyzing = "YES">
             <BuildableReference
                BuildableIdentifier = "primary"
-               BlueprintIdentifier = "212539B51B1595FD00F29EF3"
+               BlueprintIdentifier = "21B3A3D619894F4600322041"
                BuildableName = "ISO8601.framework"
-               BlueprintName = "OSX"
+               BlueprintName = "iOS"
                ReferencedContainer = "container:ISO8601.xcodeproj">
             </BuildableReference>
          </BuildActionEntry>
@@ -28,27 +28,27 @@
             buildForAnalyzing = "YES">
             <BuildableReference
                BuildableIdentifier = "primary"
-               BlueprintIdentifier = "212539BF1B1595FD00F29EF3"
-               BuildableName = "ISO8601Tests-OSX.xctest"
-               BlueprintName = "OSXTests"
+               BlueprintIdentifier = "21B3A3E119894F4600322041"
+               BuildableName = "ISO8601Tests-iOS.xctest"
+               BlueprintName = "iOSTests"
                ReferencedContainer = "container:ISO8601.xcodeproj">
             </BuildableReference>
          </BuildActionEntry>
       </BuildActionEntries>
    </BuildAction>
    <TestAction
+      buildConfiguration = "Debug"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
-      shouldUseLaunchSchemeArgsEnv = "YES"
-      buildConfiguration = "Debug">
+      shouldUseLaunchSchemeArgsEnv = "YES">
       <Testables>
          <TestableReference
             skipped = "NO">
             <BuildableReference
                BuildableIdentifier = "primary"
-               BlueprintIdentifier = "212539BF1B1595FD00F29EF3"
-               BuildableName = "ISO8601Tests-OSX.xctest"
-               BlueprintName = "OSXTests"
+               BlueprintIdentifier = "21B3A3E119894F4600322041"
+               BuildableName = "ISO8601Tests-iOS.xctest"
+               BlueprintName = "iOSTests"
                ReferencedContainer = "container:ISO8601.xcodeproj">
             </BuildableReference>
          </TestableReference>
@@ -56,9 +56,9 @@
       <MacroExpansion>
          <BuildableReference
             BuildableIdentifier = "primary"
-            BlueprintIdentifier = "212539B51B1595FD00F29EF3"
+            BlueprintIdentifier = "21B3A3D619894F4600322041"
             BuildableName = "ISO8601.framework"
-            BlueprintName = "OSX"
+            BlueprintName = "iOS"
             ReferencedContainer = "container:ISO8601.xcodeproj">
          </BuildableReference>
       </MacroExpansion>
@@ -66,11 +66,11 @@
       </AdditionalOptions>
    </TestAction>
    <LaunchAction
+      buildConfiguration = "Debug"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
       launchStyle = "0"
       useCustomWorkingDirectory = "NO"
-      buildConfiguration = "Debug"
       ignoresPersistentStateOnLaunch = "NO"
       debugDocumentVersioning = "YES"
       debugServiceExtension = "internal"
@@ -78,9 +78,9 @@
       <MacroExpansion>
          <BuildableReference
             BuildableIdentifier = "primary"
-            BlueprintIdentifier = "212539B51B1595FD00F29EF3"
+            BlueprintIdentifier = "21B3A3D619894F4600322041"
             BuildableName = "ISO8601.framework"
-            BlueprintName = "OSX"
+            BlueprintName = "iOS"
             ReferencedContainer = "container:ISO8601.xcodeproj">
          </BuildableReference>
       </MacroExpansion>
@@ -88,17 +88,17 @@
       </AdditionalOptions>
    </LaunchAction>
    <ProfileAction
+      buildConfiguration = "Release"
       shouldUseLaunchSchemeArgsEnv = "YES"
       savedToolIdentifier = ""
       useCustomWorkingDirectory = "NO"
-      buildConfiguration = "Release"
       debugDocumentVersioning = "YES">
       <MacroExpansion>
          <BuildableReference
             BuildableIdentifier = "primary"
-            BlueprintIdentifier = "212539B51B1595FD00F29EF3"
+            BlueprintIdentifier = "21B3A3D619894F4600322041"
             BuildableName = "ISO8601.framework"
-            BlueprintName = "OSX"
+            BlueprintName = "iOS"
             ReferencedContainer = "container:ISO8601.xcodeproj">
          </BuildableReference>
       </MacroExpansion>

--- a/Rakefile
+++ b/Rakefile
@@ -2,7 +2,7 @@ desc 'Run the tests'
 task :test do
   require_binary 'xcodebuild', 'brew install xcodebuild'
   require_binary 'xcpretty', 'bundle install'
-  sh 'xcodebuild test -project ISO8601.xcodeproj -scheme iOS -destination \'platform=iOS Simulator,name=iPhone 4s,OS=latest\' | bundle exec xcpretty --color; exit ${PIPESTATUS[0]}'
+  sh 'xcodebuild test -project ISO8601.xcodeproj -scheme ISO8601-iOS -destination \'platform=iOS Simulator,name=iPhone 4s,OS=latest\' | bundle exec xcpretty --color; exit ${PIPESTATUS[0]}'
 end
 
 task :default => :test


### PR DESCRIPTION
When built with Carthage, the scheme building step lists it as `Building Scheme "iOS" in ISO8601.xcodeproj`. Most of the other projects in my `Cartfile` use the pattern of `ProjectName-Platform` (including your own Crypto framework) or `ProjectName Platform`. To that end, I've renamed the schemes to

```diff
+ISO8601-iOS
-iOS

+ISO8601-OSX
-OSX
```

![nano tmux 2015-10-07 11-09-48](https://cloud.githubusercontent.com/assets/1889575/10346519/7cb3ec3c-6ce4-11e5-8b9b-361b5f3b0762.png)
