### PR TITLE
Handle daylight saving timezones by using given calendar

### DIFF
--- a/ISO8601/ISO8601Serialization.m
+++ b/ISO8601/ISO8601Serialization.m
@@ -135,9 +135,11 @@
 	if (!timeZone) {
 		return string;
 	}
-	
-	if (timeZone.secondsFromGMT != 0) {
-		NSInteger hoursOffset = timeZone.secondsFromGMT / 3600;
+
+	NSDate *date = [components.calendar dateFromComponents:components];
+	NSInteger secondsOffset = [timeZone secondsFromGMTForDate:date];
+	if (secondsOffset != 0) {
+		NSInteger hoursOffset = secondsOffset / 3600;
 		
 		// TODO: Assuming whole hour offsets at the moment
 		NSUInteger secondsOffset = 0;

--- a/ISO8601/NSDate+ISO8601.m
+++ b/ISO8601/NSDate+ISO8601.m
@@ -63,6 +63,7 @@
 		NSCalendarUnitMinute | NSCalendarUnitSecond | NSCalendarUnitTimeZone);
 	
 	NSDateComponents *dateComponents = [calendar components:units fromDate:self];
+	dateComponents.calendar = calendar;
 	return [ISO8601Serialization stringForDateComponents:dateComponents];
 }
 


### PR DESCRIPTION
This fixes an issue in which the timezone offset is derived from the current date rather than the date being operated on.