### PR TITLE
Support writing partial calendar dates

### DIFF
--- a/ISO8601/ISO8601Serialization.h
+++ b/ISO8601/ISO8601Serialization.h
@@ -35,6 +35,6 @@
  
  @return A string containing the date components as an ISO8601 string.
  */
-+ (NSString * _Nonnull)stringForDateComponents:(NSDateComponents * _Nonnull)components;
++ (NSString * __nullable)stringForDateComponents:(NSDateComponents * _Nonnull)components;
 
 @end

--- a/ISO8601/ISO8601Serialization.m
+++ b/ISO8601/ISO8601Serialization.m
@@ -126,10 +126,24 @@
 }
 
 
-+ (NSString * _Nonnull)stringForDateComponents:(NSDateComponents * _Nonnull)components {
-	NSString *string = [[NSString alloc] initWithFormat:@"%04li-%02i-%02iT%02i:%02i:%02i", (long)components.year,
-						(int)components.month, (int)components.day, (int)components.hour, (int)components.minute,
-						(int)components.second];
++ (NSString * __nullable)stringForDateComponents:(NSDateComponents * _Nonnull)components {
+	NSString *string = @"";
+	BOOL hasDate = components.year != NSDateComponentUndefined || components.month != NSDateComponentUndefined || components.day != NSDateComponentUndefined;
+	BOOL hasTime = components.hour != NSDateComponentUndefined || components.minute != NSDateComponentUndefined || components.second != NSDateComponentUndefined || components.timeZone;
+	if (!hasDate && !hasTime) {
+		return nil;
+	}
+	if (hasDate) {
+		string = [string stringByAppendingFormat:@"%04li-%02i-%02i", (long)components.year,
+		                                                              (int)components.month,
+		                                                              (int)components.day];
+	}
+	if (hasTime) {
+		string = [string stringByAppendingFormat:@"%@%02i:%02i:%02i", hasDate ? @"T" : @"",
+		                                                              (int)components.hour,
+		                                                              (int)components.minute,
+		                                                              (int)components.second];
+	}
 
 	NSTimeZone *timeZone = components.timeZone;
 	if (!timeZone) {

--- a/Tests/SerializationTests.swift
+++ b/Tests/SerializationTests.swift
@@ -162,5 +162,8 @@ class SerializationTests: XCTestCase {
 		XCTAssertEqual("2011-12-13T17:17:00-06:00", serialize(components(year: 2011, month: 12, day: 13, hour: 17, minute: 17, second: 0, timeZoneOffset: -6 * 60 * 60)))
 		XCTAssertEqual("2013-06-27T15:39:32Z", serialize(components(year: 2013, month: 6, day: 27, hour: 15, minute: 39, second: 32, timeZoneOffset: 0)))
 		XCTAssertEqual("2014-03-18T20:00:00-07:00", serialize(components(year: 2014, month: 3, day: 18, hour: 20, minute: 0, second: 0, timeZoneOffset: -7 * 60 * 60)))
+		XCTAssertEqual("2014-03-18", serialize(components(year: 2014, month: 3, day: 18)))
+		XCTAssertEqual("23:55:21", serialize(components(hour: 23, minute: 55, second: 21)))
+		XCTAssertEqual(nil, serialize(components()))
 	}
 }

--- a/Tests/TestHelper.swift
+++ b/Tests/TestHelper.swift
@@ -13,7 +13,7 @@ func parse(string: String) -> NSDateComponents? {
 	return ISO8601Serialization.dateComponentsForString(string)
 }
 
-func serialize(components: NSDateComponents) -> String {
+func serialize(components: NSDateComponents) -> String? {
 	return  ISO8601Serialization.stringForDateComponents(components)
 }
 


### PR DESCRIPTION
This addresses the following use case:

```
let x = ISO8601Serialization.dateComponentsForString("2015-12-05")
let y = ISO8601Serialization.stringForDateComponents(x)
print(y) // Should be "2015-12-05; currently outputs 2015-12-05T-1:-1:-1
````

Is this what was meant by #4?