### PR TITLE
Migrate tests to Swift 3

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,44 @@
+# Xcode
+#
+# gitignore contributors: remember to update Global/Xcode.gitignore, Objective-C.gitignore & Swift.gitignore
+
+## Build generated
+build/
+DerivedData/
+
+## Various settings
+*.pbxuser
+!default.pbxuser
+*.mode1v3
+!default.mode1v3
+*.mode2v3
+!default.mode2v3
+*.perspectivev3
+!default.perspectivev3
+xcuserdata/
+
+## Other
+*.moved-aside
+*.xcuserstate
+
+## Obj-C/Swift specific
+*.hmap
+*.ipa
+*.dSYM.zip
+*.dSYM
+
+## Playgrounds
+timeline.xctimeline
+playground.xcworkspace
+
+# Swift Package Manager
+#
+# Add this line if you want to avoid checking in source code from Swift Package Manager dependencies.
+# Packages/
+.build/
+
+# CocoaPods
+Pods/
+
+# Carthage
+Carthage/Build

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,4 @@
-osx_image: xcode7.2
+osx_image: xcode8.3
 language: objective-c
 install:
 - bundle install --jobs=3 --retry=3

--- a/ISO8601.xcodeproj/project.pbxproj
+++ b/ISO8601.xcodeproj/project.pbxproj
@@ -402,6 +402,7 @@
 					};
 					21B3A3E119894F4600322041 = {
 						CreatedOnToolsVersion = 6.0;
+						LastSwiftMigration = 0830;
 						TestTargetID = 21B3A3D619894F4600322041;
 					};
 					21EC4F361D077FCE00FA439F = {
@@ -753,6 +754,7 @@
 				MTL_ENABLE_DEBUG_INFO = YES;
 				ONLY_ACTIVE_ARCH = YES;
 				SDKROOT = iphoneos;
+				SWIFT_VERSION = 3.0;
 				TARGETED_DEVICE_FAMILY = "1,2";
 				VERSIONING_SYSTEM = "apple-generic";
 				VERSION_INFO_PREFIX = "";
@@ -797,6 +799,7 @@
 				MACOSX_DEPLOYMENT_TARGET = 10.9;
 				MTL_ENABLE_DEBUG_INFO = NO;
 				SDKROOT = iphoneos;
+				SWIFT_VERSION = 3.0;
 				TARGETED_DEVICE_FAMILY = "1,2";
 				VALIDATE_PRODUCT = YES;
 				VERSIONING_SYSTEM = "apple-generic";
@@ -856,6 +859,7 @@
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = "com.samsoffes.${PRODUCT_NAME:rfc1034identifier}";
 				PRODUCT_NAME = "ISO8601Tests-iOS";
+				SWIFT_VERSION = 3.0;
 			};
 			name = Debug;
 		};
@@ -866,6 +870,7 @@
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = "com.samsoffes.${PRODUCT_NAME:rfc1034identifier}";
 				PRODUCT_NAME = "ISO8601Tests-iOS";
+				SWIFT_VERSION = 3.0;
 			};
 			name = Release;
 		};
@@ -977,6 +982,7 @@
 				2175D2B91D171ED9009C6845 /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
 		};
 		21B3A3D119894F4600322041 /* Build configuration list for PBXProject "ISO8601" */ = {
 			isa = XCConfigurationList;

--- a/Tests/DateTests.swift
+++ b/Tests/DateTests.swift
@@ -11,19 +11,19 @@ import XCTest
 
 class DateTests: XCTestCase {
 	func testReading() {
-		var timeZone: NSTimeZone?
-		XCTAssertEqual(NSDate(ISO8601String: "2014-07-30T22:35:23Z", timeZone: &timeZone, usingCalendar: nil), NSDate(timeIntervalSince1970: 1406759723))
-		XCTAssertEqual(timeZone!.secondsFromGMT, 0)
+		var timeZone = NSTimeZone()
+		XCTAssertEqual(NSDate(iso8601String: "2014-07-30T22:35:23Z", timeZone: &timeZone, using: nil), NSDate(timeIntervalSince1970: 1406759723))
+		XCTAssertEqual(timeZone.secondsFromGMT, 0)
 
-		XCTAssertEqual(NSDate(ISO8601String: "2014-07-30T15:35:23-07:00", timeZone: &timeZone, usingCalendar: nil), NSDate(timeIntervalSince1970: 1406759723))
-		XCTAssertEqual(timeZone!.secondsFromGMT, -7 * 3600)
+		XCTAssertEqual(NSDate(iso8601String: "2014-07-30T15:35:23-07:00", timeZone: &timeZone, using: nil), NSDate(timeIntervalSince1970: 1406759723))
+		XCTAssertEqual(timeZone.secondsFromGMT, -7 * 3600)
 	}
 
     func testFailingReading() {
-		XCTAssertNil(NSDate(ISO8601String: "WRONG DATA"))
+		XCTAssertNil(NSDate(iso8601String: "WRONG DATA"))
     }
 
 	func testWriting() {
-		XCTAssertEqual(NSDate(timeIntervalSince1970: 1406759723).ISO8601StringWithTimeZone(nil, usingCalendar: nil), "2014-07-30T22:35:23Z")
+		XCTAssertEqual(NSDate(timeIntervalSince1970: 1406759723).iso8601String(with: nil, using: nil), "2014-07-30T22:35:23Z")
 	}
 }

--- a/Tests/TestHelper.swift
+++ b/Tests/TestHelper.swift
@@ -9,15 +9,15 @@
 import ISO8601
 import Foundation
 
-func parse(string: String) -> NSDateComponents? {
-	return ISO8601Serialization.dateComponentsForString(string)
+func parse(_ string: String) -> NSDateComponents? {
+	return ISO8601Serialization.dateComponents(for: string) as NSDateComponents?
 }
 
-func serialize(components: NSDateComponents) -> String? {
-	return  ISO8601Serialization.stringForDateComponents(components)
+func serialize(_ components: NSDateComponents) -> String? {
+	return  ISO8601Serialization.string(for: components as DateComponents)
 }
 
-func components(year year: Int? = nil, month: Int? = nil, day: Int? = nil, hour: Int? = nil, minute: Int? = nil, second: Int? = nil, timeZoneOffset: NSTimeInterval? = nil) -> NSDateComponents {
+func components(year: Int? = nil, month: Int? = nil, day: Int? = nil, hour: Int? = nil, minute: Int? = nil, second: Int? = nil, timeZoneOffset: TimeInterval? = nil) -> NSDateComponents {
 	let comps = NSDateComponents()
 	if let year = year {
 		comps.year = year
@@ -44,7 +44,7 @@ func components(year year: Int? = nil, month: Int? = nil, day: Int? = nil, hour:
 	}
 
 	if let timeZoneOffset = timeZoneOffset {
-		comps.timeZone = NSTimeZone(forSecondsFromGMT: Int(timeZoneOffset))
+		comps.timeZone = TimeZone(secondsFromGMT: Int(timeZoneOffset))
 	}
 	return comps
 }


### PR DESCRIPTION
With this pull request

- Gitignore added
- Unit tests migrated to Swift 3
- OSX image version updated to 8.3 on travis config